### PR TITLE
Convert ?MODULE to list when used in filename:join

### DIFF
--- a/src/tempo.erl
+++ b/src/tempo.erl
@@ -206,7 +206,7 @@ nif_init() ->
                   Path ->
                       Path
               end,
-    erlang:load_nif(filename:join(PrivDir, ?MODULE), 0).
+    erlang:load_nif(filename:join(PrivDir, atom_to_list(?MODULE)), 0).
 
 %% @private
 %% @doc Helper for exiting gracefully when NIF can't be loaded.


### PR DESCRIPTION
I copied your NIF init/0 code, and when I ran my code through dialyzer, it got an error:

```
esu_comms.erl:44: The call filename:join(PrivDir::binary() | string(),'esu_comms')
breaks the contract (Name1,Name2) -> file:filename() when is_subtype(Name1,file:filename()),
is_subtype(Name2,file:filename())
```

Turns out that there was a filename:join(Foo, ?MODULE), but ?MODULE is an atom. This is the same fix I applied to my code.
